### PR TITLE
Changed flow of working with directories for monsoon.

### DIFF
--- a/qiime2-assignment.ipynb
+++ b/qiime2-assignment.ipynb
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`cd` allows you to change to a directory. `cd ..` allows you to change out of the directory that you're currently in to the directory that contains the directory that you're currently in. In the cells below use `ls` to find a directory `cd` into that directory and then return to the original directory and `ls` to show that you are back."
+    "`cd` allows you to change to a directory. mkdir allows you to create a directory. `cd ..` allows you to change out of the directory that you're currently in to the directory that contains the directory that you're currently in. In the cells below use mkdir to create a new directory and then use `ls` to find that directory and `cd` into that directory and then return to the original directory and `ls` to show that you are back."
    ]
   },
   {
@@ -109,14 +109,27 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "mkdir emp-single-end-sequences"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+   "cd emp-single-end-sequences"
+   ]
   },
   {
    "cell_type": "code",
@@ -211,7 +224,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, create a directory and download the two sequence data files to that directory."
+    "Next, use your created directory and download the two sequence data files to that directory."
    ]
   },
   {
@@ -220,7 +233,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mkdir emp-single-end-sequences\n",
     "wget -O \"emp-single-end-sequences/barcodes.fastq.gz\" \"https://data.qiime2.org/2019.1/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz\"\n",
     "wget -O \"emp-single-end-sequences/sequences.fastq.gz\" \"https://data.qiime2.org/2019.1/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz\""
    ]


### PR DESCRIPTION
I made changes to create a directory prior to using cd .. as this puts students into an unfamiliar place on Monsoon that may cause confusion. Now they first create the directory, use `ls` to see the directory, `cd` into that directory, `ls` again, and then `cd ..` out of that directory.